### PR TITLE
CE-11202: Fix download extract timestamp warning by adding using the …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,6 +133,6 @@ def buildConfig(String src, String tgt, Map cfg, List deps, List defs) {
 	unstash(name: SOURCE_STASH)
 	deps.each { d -> papl.fetchDependency(d, cfg) }
 	dir(path: 'build') {
-		papl.runCMakeBuild(src, tgt, cfg, defs)
+		papl.runCMakeBuild(src, tgt, cfg, defs, JenkinsTools.CMAKE319)
 	}
 }

--- a/examples/prt4cmd/src/CMakeLists.txt
+++ b/examples/prt4cmd/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.11)
 cmake_policy(SET CMP0015 NEW)
 if(POLICY CMP0135)
 	cmake_policy(SET CMP0135 NEW)

--- a/examples/prt4cmd/src/CMakeLists.txt
+++ b/examples/prt4cmd/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.3)
 cmake_policy(SET CMP0015 NEW)
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+endif()
 
 
 ### project definition

--- a/examples/prt4cmd/src/CMakeLists.txt
+++ b/examples/prt4cmd/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.19)
 cmake_policy(SET CMP0015 NEW)
 if(POLICY CMP0135)
 	cmake_policy(SET CMP0135 NEW)

--- a/examples/stldec/src/CMakeLists.txt
+++ b/examples/stldec/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.11)
 cmake_policy(SET CMP0015 NEW)
 if(POLICY CMP0135)
 	cmake_policy(SET CMP0135 NEW)

--- a/examples/stldec/src/CMakeLists.txt
+++ b/examples/stldec/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.3)
 cmake_policy(SET CMP0015 NEW)
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+endif()
 
 
 ### project definition

--- a/examples/stldec/src/CMakeLists.txt
+++ b/examples/stldec/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.19)
 cmake_policy(SET CMP0015 NEW)
 if(POLICY CMP0135)
 	cmake_policy(SET CMP0135 NEW)

--- a/examples/stlenc/src/CMakeLists.txt
+++ b/examples/stlenc/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.11)
 cmake_policy(SET CMP0015 NEW)
 if(POLICY CMP0135)
 	cmake_policy(SET CMP0135 NEW)

--- a/examples/stlenc/src/CMakeLists.txt
+++ b/examples/stlenc/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.3)
 cmake_policy(SET CMP0015 NEW)
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+endif()
 
 
 ### project definition

--- a/examples/stlenc/src/CMakeLists.txt
+++ b/examples/stlenc/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.19)
 cmake_policy(SET CMP0015 NEW)
 if(POLICY CMP0135)
 	cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
…new policy

The warning warns us that using the old policy will result in potential issues when adding extenal projects with EternalProject_Add() without the DOWNLOAD_EXTRACT_TIMESTAMP option. see https://cmake.org/cmake/help/latest/policy/CMP0135.html

We never use that command, but it doesn't hurt to use the new policy and thereby supress the warning.